### PR TITLE
Add an obfuscateString function to logrus.utils

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,0 +1,3 @@
+# 0.4
+
+Added obfuscateString function

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 ## Table of Contents
 
-- [logrus](#logrus)
 - [Installation](#installation)
 - [License](#license)
 - [Included Commands](#included-commands)
@@ -26,6 +25,7 @@
     - [humanTime(seconds)](#humantimeseconds)
   - [logrus.utils](#logrusutils)
     - [mkdir_p(path)](#mkdir_ppath)
+    - [obfuscateString(snippet, showLength=5, smear='*')](#obfuscatestringsnippet-showlength5-smear)
     - [squashDicts(*dict_args)](#squashdictsdict_args)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -160,6 +160,10 @@ Takes a value in seconds, returns it in meat-friendly format. `humanFriendlyTime
 ### mkdir_p(path)
 
 os module doesn't have a `mkdir -p` equivalent so added one.
+
+### obfuscateString(snippet, showLength=5, smear='*')
+
+Takes a string, chops off showLength characters from the beginning and end and replaces everything else with the `smear` character. Really only useful for displaying just enough of a credential in a log to show it's using the correct credential, but not revealing the actual credential.
 
 ### squashDicts(*dict_args)
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # The Logrus
 #
-# Copyright 2015-2019 Joe Block <jpb@unixorn.net>
+# Copyright 2015-2020 Joe Block <jpb@unixorn.net>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,10 @@
 # limitations under the License.
 
 '''
-logrus is a collection of utility functions.
+logrus is a collection of miscellaneous utility functions.
+
+Nothing in here is all that special, it's just some functions I use a lot
+and don't want to keep rewriting.
 '''
 
 import os
@@ -38,7 +41,7 @@ def run(command):
 
 
 PACKAGE_NAME = 'thelogrus'
-PACKAGE_VERSION = "0.3.%s" % (run('git rev-list HEAD --count').strip())
+PACKAGE_VERSION = "0.4.%s" % (run('git rev-list HEAD --count').strip())
 
 
 class CleanCommand(Command):

--- a/thelogrus/utils.py
+++ b/thelogrus/utils.py
@@ -47,3 +47,17 @@ def squashDicts(*dict_args):
   for dictionary in dict_args:
     result.update(dictionary)
   return result
+
+def obfuscateString(snippet, showLength=5, smear='*'):
+  '''Obfuscate a string so we can show parts of it in debug log
+
+  :param str snippet: String to obfuscate
+  :param int showLength: How many characters _not_ to obscure and beginning and end of string
+  :param char smear: character to replace obscured characters with
+  '''
+  start = snippet[:int(showLength)]
+
+  trailing = snippet[(int(showLength)* -1):]
+
+  obscured = ( len(snippet) - (2 * showLength) ) * smear
+  return "%s%s%s" % (start, obscured, trailing)


### PR DESCRIPTION
Got tired of rewriting a function to display just part of a credential in a log so I can confirm the app is using the right credentials without also exposing the credential to anyone running the tool.